### PR TITLE
Adding functions to inject egress rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I use this function to only allow Github webhooks access my Jenkins instance hos
     
 ## Function code for GitHub
 
-* **Python** 2.7
+* **Python** 3.7
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ I use this function to only allow Github webhooks access my Jenkins instance hos
 
 ## Environment variables
 
-**key:** PORTS_LIST
-**value:** 8001,8002
+**key:** INGRESS_PORTS_LIST
+**value:** 80,443
+
+**key:** EGRESS_PORTS_LIST
+**value:** 22,80,443
 
 **key:** SECURITY_GROUP_ID
 **value:** add your security group id here

--- a/allow-ec2-security-group-role
+++ b/allow-ec2-security-group-role
@@ -5,6 +5,7 @@
             "Effect": "Allow",
             "Action": [
                 "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
                 "ec2:DescribeSecurityGroups"
             ],
             "Resource": [

--- a/allow-ec2-security-group-role
+++ b/allow-ec2-security-group-role
@@ -6,7 +6,10 @@
             "Action": [
                 "ec2:AuthorizeSecurityGroupIngress",
                 "ec2:AuthorizeSecurityGroupEgress",
-                "ec2:DescribeSecurityGroups"
+                "ec2:DescribeSecurityGroups",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
             ],
             "Resource": [
                 "*"

--- a/github-ip-lambda-function.py
+++ b/github-ip-lambda-function.py
@@ -1,6 +1,6 @@
 import os
 import boto3
-from botocore.vendored import requests
+import botocore.vendored.requests as requests
 
 
 def get_github_ip_list():
@@ -74,7 +74,7 @@ def add_ingress_rule(group, address, port, description):
         }
     ]
     group.authorize_ingress(IpPermissions=permissions)
-    print("Ingress rule from IP %s to Port %i has been added" % (address, port))
+    print(("Ingress rule from IP %s to Port %i has been added" % (address, port)))
 
 
 def add_egress_rule(group, address, port, description):
@@ -101,7 +101,7 @@ def add_egress_rule(group, address, port, description):
         }
     ]
     group.authorize_egress(IpPermissions=permissions)
-    print("Egress rule to IP %s from Port %i has been added" % (address, port))
+    print(("Egress rule to IP %s from Port %i has been added" % (address, port)))
 
 
 def lambda_handler(event, context):

--- a/github-ip-lambda-function.py
+++ b/github-ip-lambda-function.py
@@ -50,7 +50,7 @@ def check_rule_exists(rules, address, port):
     return False
 
 
-def add_rule(group, address, port, description):
+def add_ingress_rule(group, address, port, description):
     """
     Add the IP address and port to the security group
 
@@ -74,7 +74,34 @@ def add_rule(group, address, port, description):
         }
     ]
     group.authorize_ingress(IpPermissions=permissions)
-    print("Added %s : %i  " % (address, port))
+    print("Ingress rule from IP %s to Port %i has been added" % (address, port))
+
+
+def add_egress_rule(group, address, port, description):
+    """
+    Add the IP address and port to the security group
+
+    :param group:
+    :param address:
+    :param port:
+    :param description:
+    :return:
+    """
+    permissions = [
+        {
+            'IpProtocol': 'tcp',
+            'FromPort': port,
+            'ToPort': port,
+            'IpRanges': [
+                {
+                    'CidrIp': address,
+                    'Description': description,
+                }
+            ],
+        }
+    ]
+    group.authorize_egress(IpPermissions=permissions)
+    print("Egress rule to IP %s from Port %i has been added" % (address, port))
 
 
 def lambda_handler(event, context):
@@ -85,16 +112,24 @@ def lambda_handler(event, context):
     :param context:
     :return:
     """
-    ports = [int(port) for port in os.environ['PORTS_LIST'].split(",")]
-    if not ports:
-        ports = [80]
+    ingress_ports = [int(port) for port in os.environ['INGRESS_PORTS_LIST'].split(",")]
+    if not ingress_ports:
+        ingress_ports = [80]
+
+    egress_ports = [int(port) for port in os.environ['EGRESS_PORTS_LIST'].split(",")]
+    if not egress_ports:
+        egress_ports = [22]
 
     security_group = get_aws_security_group(os.environ['SECURITY_GROUP_ID'])
-    current_rules = security_group.ip_permissions
+    current_ingress_rules = security_group.ip_permissions
+    current_egress_rules = security_group.ip_permissions_egress
     ip_addresses = get_github_ip_list()
-    description = "Authorize GitHub webhooks access"
+    description = "GitHub"
 
     for ip_address in ip_addresses:
-        for port in ports:
-            if not check_rule_exists(current_rules, ip_address, port):
-                add_rule(security_group, ip_address, port, description)
+        for port in ingress_ports:
+            if not check_rule_exists(current_ingress_rules, ip_address, port):
+                add_ingress_rule(security_group, ip_address, port, description)
+        for port in egress_ports:
+            if not check_rule_exists(current_egress_rules, ip_address, port):
+                add_egress_rule(security_group, ip_address, port, description)


### PR DESCRIPTION
Now, this script is capable of injecting both ingress and egress rules. Therefore you can easily perform git clone operations over the port 22/TCP which is open to GitHub IP ranges only.