### PR TITLE
Add `requests` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,21 @@ I use this function to only allow Github webhooks access my Jenkins instance hos
 
 * Schedule expression: rate(1 day)
 * Enabled
-    
+
 ## Function code for GitHub
 
-* **Python** 3.7
+* **Python** 3.8
+* **External Dependencies**: [requests](https://pypi.org/project/requests/)
 
 ## Environment variables
 
-**key:** INGRESS_PORTS_LIST
+**key:** INGRESS_PORTS_LIST  
 **value:** 80,443
 
-**key:** EGRESS_PORTS_LIST
+**key:** EGRESS_PORTS_LIST  
 **value:** 22,80,443
 
-**key:** SECURITY_GROUP_ID
+**key:** SECURITY_GROUP_ID  
 **value:** add your security group id here
 
 If required you can create a custom security group using the below command line:
@@ -31,18 +32,17 @@ If required you can create a custom security group using the below command line:
 
 * **Role Name:** github-ip-security-group-update
 
-Required rule to allow the lambda function to edit the security group, use the content of the _allow-ec2-security-group-role_ file       
+Required rule to allow the lambda function to edit the security group, use the content of the _allow-ec2-security-group-role_ file
 
 ## Time out
 
 Set the Timeout to 8 seconds
-    
+
 ## Room for improvement
 
 If you happen to find something not to your liking, you are welcome to send a PR.
 
-**Ref.:** 
+**Ref.:**
 
 * [https://api.github.com/meta](https://api.github.com/meta)
 * [https://help.github.com/articles/about-github-s-ip-addresses/](https://help.github.com/articles/about-github-s-ip-addresses/)
-

--- a/github-ip-lambda-function.py
+++ b/github-ip-lambda-function.py
@@ -1,6 +1,6 @@
 import os
 import boto3
-import botocore.vendored.requests as requests
+import requests
 
 
 def get_github_ip_list():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3
 botocore
+requests


### PR DESCRIPTION
[AWS deprecating](https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/) `requests` from `botocore` soon. 
```
DeprecationWarning: You are using the get() function from 'botocore.vendored.requests'. This dependency was removed from Botocore and will be removed from Lambda after 2021/01/30. https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/. Install the requests package, 'import requests' directly, and use the requests.get() function instead.
```
The solution is to use old SDK or install requests and upload the code as zip.
Added `requests` to the `requirements.txt` file and updated the readme.
Also tested it with python 3.8 and it works fine