### PR TITLE
Added ipv6 support

### DIFF
--- a/github-ip-lambda-function.py
+++ b/github-ip-lambda-function.py
@@ -60,19 +60,34 @@ def add_ingress_rule(group, address, port, description):
     :param description:
     :return:
     """
-    permissions = [
-        {
-            'IpProtocol': 'tcp',
-            'FromPort': port,
-            'ToPort': port,
-            'IpRanges': [
-                {
-                    'CidrIp': address,
-                    'Description': description,
-                }
-            ],
-        }
-    ]
+    if "." in address:
+        permissions = [
+            {
+                'IpProtocol': 'tcp',
+                'FromPort': port,
+                'ToPort': port,
+                'IpRanges': [
+                    {
+                        'CidrIp': address,
+                        'Description': description,
+                    }
+                ],
+            }
+        ]
+    else:
+        permissions = [
+            {
+                'IpProtocol': 'tcp',
+                'FromPort': port,
+                'ToPort': port,
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': address,
+                        'Description': description,
+                    }
+                ],
+            }
+        ]
     group.authorize_ingress(IpPermissions=permissions)
     print(("Ingress rule from IP %s to Port %i has been added" % (address, port)))
 
@@ -87,19 +102,34 @@ def add_egress_rule(group, address, port, description):
     :param description:
     :return:
     """
-    permissions = [
-        {
-            'IpProtocol': 'tcp',
-            'FromPort': port,
-            'ToPort': port,
-            'IpRanges': [
-                {
-                    'CidrIp': address,
-                    'Description': description,
-                }
-            ],
-        }
-    ]
+    if "." in address:
+        permissions = [
+            {
+                'IpProtocol': 'tcp',
+                'FromPort': port,
+                'ToPort': port,
+                'IpRanges': [
+                    {
+                        'CidrIp': address,
+                        'Description': description,
+                    }
+                ],
+            }
+        ]
+    else:
+        permissions = [
+            {
+                'IpProtocol': 'tcp',
+                'FromPort': port,
+                'ToPort': port,
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': address,
+                        'Description': description,
+                    }
+                ],
+            }
+        ]
     group.authorize_egress(IpPermissions=permissions)
     print(("Egress rule to IP %s from Port %i has been added" % (address, port)))
 


### PR DESCRIPTION
The SG authorize SDK syntax is different for IP v6 addresses, so this was failing for those.  I am checking to see if it is an IP v4 address (if it has a "." in the address) or IP v6 address (otherwise) and using the correct syntax.